### PR TITLE
database choice

### DIFF
--- a/conda_environment.sh
+++ b/conda_environment.sh
@@ -1,0 +1,2 @@
+mamba create  -n fusionreport
+mamba env update -n fusionreport --file conda_environment.yml

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,0 +1,14 @@
+name: fusionreport
+
+channels:
+  - conda-forge
+  - defaults
+  - anaconda
+  - bioconda
+
+
+dependencies:
+  - notebook=6.4.8
+  - nb_conda_kernels=2.3.1
+  - openpyxl=3.0.9
+  - fusion-report=2.1.5

--- a/fusion_report/app.py
+++ b/fusion_report/app.py
@@ -80,7 +80,7 @@ class App:
     def preprocess(self, params: Namespace) -> None:
         """Parse, enrich and score fusion."""
         self.parse_fusion_outputs(vars(params))
-        self.enrich(params.db_path)
+        self.enrich(params)
         self.score(vars(params))
 
     def generate_report(self, params: Namespace) -> None:
@@ -135,14 +135,20 @@ class App:
                 # value: fusion tool output
                 self.manager.parse(param, value, params['allow_multiple_gene_symbols'])
 
-    def enrich(self, path: str) -> None:
+    def enrich(self, params: Namespace) -> None:
         """Enrich fusion with all relevant information from local databases."""
-        local_fusions: Dict[str, List[str]] = {
-            CosmicDB(path).name: CosmicDB(path).get_all_fusions(),
-            MitelmanDB(path).name: MitelmanDB(path).get_all_fusions(),
-            FusionGDB(path).name: FusionGDB(path).get_all_fusions(),
-            FusionGDB2(path).name: FusionGDB2(path).get_all_fusions()
-        }
+        path: str = params.db_path
+        local_fusions: Dict[str, List[str]] = {}
+        if params.use_cosmic:
+            local_fusions[CosmicDB(path).name] = CosmicDB(path).get_all_fusions()
+        if params.use_mitelman:
+            local_fusions[MitelmanDB(path).name] = MitelmanDB(path).get_all_fusions()
+        if params.use_fusiongdb:
+            local_fusions[FusionGDB(path).name] = FusionGDB(path).get_all_fusions()
+        if params.use_fusiongdb2:
+            local_fusions[FusionGDB2(path).name] = FusionGDB(path).get_all_fusions()
+        
+
         for fusion in self.manager.fusions:
             for db_name, db_list in local_fusions.items():
                 if fusion.name in db_list:

--- a/fusion_report/arguments.json
+++ b/fusion_report/arguments.json
@@ -13,6 +13,30 @@
                 {
                     "key": "db_path",
                     "help": "Path to folder where all databases are stored."
+                },
+                {
+                    "key": "--use_cosmic",
+                    "help": "Use cosmic database",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_mitelman",
+                    "help": "Use Mitelman database",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_fusiongdb",
+                    "help": "Use FusionGDB",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_fusiongdb2",
+                    "help": "Use FusionGDB2",
+                    "type": "bool",
+                    "default": false
                 }
             ],
             "tools": [

--- a/fusion_report/arguments.json
+++ b/fusion_report/arguments.json
@@ -77,7 +77,32 @@
                 {
                     "key": "output",
                     "help": "Output directory"
+                },
+                {
+                    "key": "--use_cosmic",
+                    "help": "Use cosmic database",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_mitelman",
+                    "help": "Use Mitelman database",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_fusiongdb",
+                    "help": "Use FusionGDB",
+                    "type": "bool",
+                    "default": false
+                },
+                {
+                    "key": "--use_fusiongdb2",
+                    "help": "Use FusionGDB2",
+                    "type": "bool",
+                    "default": false
                 }
+
             ],
             "cosmic": [
                 {

--- a/fusion_report/download.py
+++ b/fusion_report/download.py
@@ -23,11 +23,14 @@ class Download:
 
     def validate(self, params: Namespace) -> None:
         """Method validating required input. In this case COSMIC credentials."""
-        self.cosmic_token = Net.get_cosmic_token(params)
+        
 
         # making sure output directory exists
         if not os.path.exists(params.output):
-            os.makedirs(params.output, 0o755)
+                os.makedirs(params.output, 0o755)
+        if params.use_cosmic:
+            self.cosmic_token = Net.get_cosmic_token(params)
+            
 
     def download_all(self, params: Namespace) -> None:
         """Download all databases."""
@@ -35,16 +38,20 @@ class Download:
         os.chdir(params.output)
 
         # MITELMAN
-        Net.get_mitelman(self, return_err)
+        if params.use_mitelman:
+            Net.get_mitelman(self, return_err)
 
         # FusionGDB
-        Net.get_fusiongdb(self, return_err)
+        if params.use_fusiongdb:
+            Net.get_fusiongdb(self, return_err)
 
         # FusionGDB2
-        Net.get_fusiongdb2(self, return_err)
+        if params.use_fusiongdb2:
+            Net.get_fusiongdb2(self, return_err)
 
         # COSMIC
-        Net.get_cosmic(self.cosmic_token, return_err)
+        if params.use_cosmic:
+            Net.get_cosmic(self.cosmic_token, return_err)
 
         if len(return_err) > 0:
             raise DownloadException(return_err)


### PR DESCRIPTION
# Database choice

The current version doesn't seem to necessarily allow for choosing which database to download / use as mentioned in #48 , so I have drafted this PR.

My goal is that the database used would be explicitly declared, so each database has its own flag added to the `arguments.json` file for run and download. The idea being that to just download mitelman, you could run `fusion_report download --use_mitelman true database_output` if you just wanted to download that one database, or any combination of `--use_cosmic`, `--use_mitelman`, `--use_fusiongdb` and `--use_fusiongdb2`.  For my purposes, I only wanted to download mitelman, fusiongdb and fusiongdb2. So I can now run the following:

```bash
fusion_report download  --use_mitelman true --use_fusiongdb true --use_fusiongdb2 true fusionreport_download
```
Further, to run on the test dataset, I can use the following:

```bash
fusion_report run "test" test_output fusionreport_download/ \
  --use_mitelman true --use_fusiongdb true --use_fusiongdb2 true \
  --arriba tests/test_data/arriba.tsv \
  --dragen tests/test_data/dragen.tsv \
  --ericscript tests/test_data/ericscript.tsv \
  --fusioncatcher tests/test_data/fusioncatcher.txt \
  --pizzly tests/test_data/pizzly.tsv \
  --squid tests/test_data/squid.txt \
  --starfusion tests/test_data/starfusion.tsv \
  --jaffa tests/test_data/jaffa.csv \
  --allow-multiple-gene-symbols
```

I also included a conda environment file, which I included as I used it with a jupyter notebook to play around with the library, so I thought it might be useful as well.

Let me know what you think.

## Checklist

- [x] Specify in detail the change
- [ ] Make sure to follow guidelines in `docs` when adding database/tool
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README` is updated
