### PR TITLE
Mitelman DB patch

### DIFF
--- a/fusion_report/common/net.py
+++ b/fusion_report/common/net.py
@@ -135,7 +135,7 @@ class Net:
             url: str = f'{Settings.MITELMAN["HOSTNAME"]}/{Settings.MITELMAN["FILE"]}'
             Net.get_large_file(url)
             with ZipFile(Settings.MITELMAN['FILE'], 'r') as archive:
-                files = [x for x in archive.namelist() if "mitelman_db/MBCA.TXT.DATA" in x]
+                files = [x for x in archive.namelist() if "MBCA.TXT.DATA" in x]
                 archive.extractall()
 
             db = MitelmanDB('.')


### PR DESCRIPTION
This fixes part of issue #52 where the `mitelman.db` file was no longer building. 

The database files were unzipping, but not to a sub-directory. Removing the incorrect path to `MBCA.TXT.DATA` results in a correct `mitelman.db` build
